### PR TITLE
Hot fix string multiline widget value updates in ComfyUI frontend

### DIFF
--- a/js/showcontrol.js
+++ b/js/showcontrol.js
@@ -100,6 +100,9 @@ function toggleWidget(node, widget, show = false, suffix = "") {
 app.registerExtension({
     name: "inpaint-cropandstitch.showcontrol",
     nodeCreated(node) {
+        if (node.comfyClass !== "InpaintCrop")
+            return;
+        
         inpaintCropAndStitchHandler(node);
         for (const w of node.widgets || []) {
             let widgetValue = w.value;
@@ -118,7 +121,6 @@ app.registerExtension({
                     return valueToReturn;
                 },
                 set(newVal) {
-
                     // If there's an original setter, use it. Otherwise, set widgetValue.
                     if (originalDescriptor && originalDescriptor.set) {
                         originalDescriptor.set.call(w, newVal);


### PR DESCRIPTION
With the latest update to ComfyUI_frontend https://github.com/Comfy-Org/ComfyUI_frontend, string multiline widget values stopped updating correctly in the UI. The issue was caused by using Object.getOwnPropertyDescriptor on the widget instance, which now returns undefined because the 'value' property is defined on the widget’s prototype. 

This commit fixes the problem by falling back to retrieving the property descriptor from the widget's prototype when necessary. As a result, the getter and setter work as intended, and the widget values update properly.

PS: I also restricted adding properties to InpaintCrop only.

Issue:
![{DE2F5D5D-C4A9-45E6-BA3C-97841FFA3C16}](https://github.com/user-attachments/assets/238725b3-b67e-4736-aaec-af05c7b14a4d)
