### PR TITLE
Add accumulate option to inpaint_stitch

### DIFF
--- a/inpaint_cropandstitch.py
+++ b/inpaint_cropandstitch.py
@@ -1287,8 +1287,8 @@ class InpaintCropImproved:
         if device_mode == "gpu (much faster)":
             device = comfy.model_management.get_torch_device()
             image = image.to(device)
-            if mask is not None: mask = mask.to(device)
-            if optional_context_mask is not None: optional_context_mask = optional_context_mask.to(device)
+            if mask is not None: mask = mask.to(device).float()
+            if optional_context_mask is not None: optional_context_mask = optional_context_mask.to(device).float()
             processor = GPUProcessorLogic()
         else:
             processor = CPUProcessorLogic()


### PR DESCRIPTION
Added a toggle to the stitch node that when enabled, all inpainted regions are combined into a single output image (first in batch). Use this when you have multiple masks for different regions of the same image and want them all merged into one result.

Sending multiple masks is helpful when wanting to simultaneously inpaint objects on opposite ends of an image that would result in a large mask bounding box and thus large image to process for inpainting.